### PR TITLE
Fix Dockerfile for missing script error

### DIFF
--- a/server/TableService/TableService/Dockerfile
+++ b/server/TableService/TableService/Dockerfile
@@ -8,7 +8,7 @@ EXPOSE 80
 COPY . .
 
 # Make script executable
-RUN chmod +x ./wait-for-postgres.sh
+RUN chmod +x ./wait-for-postgres.sh || true
 
 # Restore packages
 RUN dotnet restore
@@ -22,9 +22,9 @@ FROM mcr.microsoft.com/dotnet/aspnet:7.0
 
 WORKDIR /app
 
-# Install psql
+# Install psql and dos2unix
 RUN apt-get update \
-    && apt-get install -y postgresql-client \
+    && apt-get install -y postgresql-client dos2unix \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy to out
@@ -32,6 +32,6 @@ COPY --from=build /app/out .
 
 # Copy the script into the Docker container
 COPY wait-for-postgres.sh ./
-RUN chmod +x ./wait-for-postgres.sh
+RUN dos2unix wait-for-postgres.sh && chmod +x ./wait-for-postgres.sh
 
 CMD /app/wait-for-postgres.sh postgres dotnet TableService.dll


### PR DESCRIPTION
Error: `2023-05-16 20:02:27 /bin/sh: 1: /app/wait-for-postgres.sh: not found`


This Dockerfile now will convert the line endings of the script to the correct format for Linux and ensure the script is executable. 

It will also continue building even if the script does not exist, which will allow you to check whether the rest of the Dockerfile is correct. (We may consider removing this later)